### PR TITLE
Always make a copy of completionHandler in checkForDeferredDeepLinkWithCompletionHandler

### DIFF
--- a/mParticle-BranchMetrics/MPKitBranchMetrics.m
+++ b/mParticle-BranchMetrics/MPKitBranchMetrics.m
@@ -195,12 +195,11 @@ NSString *const ekBMAForwardScreenViews = @"forwardScreenViews";
 }
 
 - (MPKitExecStatus *)checkForDeferredDeepLinkWithCompletionHandler:(void(^)(NSDictionary<NSString *, NSString *> *linkInfo, NSError *error))completionHandler {
+    completionHandlerCopy = [completionHandler copy];
     if (_started && (temporaryParams || temporaryError)) {
         completionHandler(temporaryParams, temporaryError);
         temporaryParams = nil;
         temporaryError = nil;
-    } else {
-        completionHandlerCopy = [completionHandler copy];
     }
 
     MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceBranchMetrics) returnCode:MPKitReturnCodeSuccess];


### PR DESCRIPTION
With Branch they keep a reference to the deep link handler so that when a deep link is processed the handler is called. Likewise in this integration it should always keep a copy of the deep link handler so that if a user opens the app from a deep link, then backgrounds the app, and then clicks another deep link it should re-run the registered deep link handler.
