### PR TITLE
Remove NSDictionary generic specifications for checkForDeferredDeepLinkWithCompletionHandler callback

### DIFF
--- a/mParticle-BranchMetrics/MPKitBranchMetrics.m
+++ b/mParticle-BranchMetrics/MPKitBranchMetrics.m
@@ -36,7 +36,7 @@ NSString *const ekBMAForwardScreenViews = @"forwardScreenViews";
     BOOL forwardScreenViews;
     NSDictionary *temporaryParams;
     NSError *temporaryError;
-    void (^completionHandlerCopy)(NSDictionary<NSString *, NSString *> *, NSError *);
+    void (^completionHandlerCopy)(NSDictionary *, NSError *);
 }
 
 @end
@@ -215,7 +215,7 @@ NSString *const ekBMAForwardScreenViews = @"forwardScreenViews";
     return execStatus;
 }
 
-- (MPKitExecStatus *)checkForDeferredDeepLinkWithCompletionHandler:(void(^)(NSDictionary<NSString *, NSString *> *linkInfo, NSError *error))completionHandler {
+- (MPKitExecStatus *)checkForDeferredDeepLinkWithCompletionHandler:(void(^)(NSDictionary *linkInfo, NSError *error))completionHandler {
     if (_started && (temporaryParams || temporaryError)) {
         completionHandler(temporaryParams, temporaryError);
         temporaryParams = nil;


### PR DESCRIPTION
This PR is dependent on [PR 33](https://github.com/mParticle/mparticle-apple-sdk/pull/33) in mparticle/mparticle-apple-sdk.

Because the callback for `checkForDeferredDeepLinkWithCompletionHandler` traces its NSDictionary all the way back to `[Branch getLatestReferringParams]`, which doesn’t specify generics for NSDictionary, there is no guarantee that the keys and values will be of type `<NSString *, NSString *>`. This proves to be an issue when bridging to Swift, as there are times when `[Branch getLatestreferringParams]` _can_ return a dictionary of type `[NSObject : AnyObject]`, which causes a crash at runtime because Swift is expecting `[String : String]`, but is getting `[String : NSNumber]`.

Therefore, the callback can only be as specific as its upstream dependencies, which is to say, not at all. Thus, removing the <NSString *, NSString *> generic specification on the callback.

Removing the specification results in bridging to `[NSObject : AnyObject]` when consumed in Swift, which requires the consumer to cast from `AnyObject` to the expected type (`String` in this case) when pulling values out of the dictionary.

Here is how I’ve implemented the contract change in our code:

```
MParticle.sharedInstance().checkForDeferredDeepLinkWithCompletionHandler { linkInfo, error in
    if let canonicalURL = linkInfo?["$canonical_url"] as? String, let url = NSURL(string: canonicalURL) {
        navigateToLink(url)
    }
}
```
