### PR TITLE
Remove logEvent+logScreen for firehose integration

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "BranchMetrics/ios-branch-deep-linking" == 0.12.24
+github "BranchMetrics/ios-branch-deep-linking" == 0.12.27
 github "mparticle/mparticle-apple-sdk" ~> 6.12.0

--- a/mParticle-BranchMetrics.podspec
+++ b/mParticle-BranchMetrics.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "8.0"
     s.ios.source_files      = 'mParticle-BranchMetrics/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 6.12.0'
-    s.ios.dependency 'Branch', '0.12.24'
+    s.ios.dependency 'Branch', '0.12.27'
 end

--- a/mParticle-BranchMetrics/MPKitBranchMetrics.m
+++ b/mParticle-BranchMetrics/MPKitBranchMetrics.m
@@ -129,37 +129,6 @@ NSString *const ekBMAForwardScreenViews = @"forwardScreenViews";
     return execStatus;
 }
 
-- (MPKitExecStatus *)logEvent:(MPEvent *)event {
-    if (event.info.count > 0) {
-        [branchInstance userCompletedAction:event.name withState:event.info];
-    } else {
-        [branchInstance userCompletedAction:event.name];
-    }
-
-    MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceBranchMetrics) returnCode:MPKitReturnCodeSuccess];
-    return execStatus;
-}
-
-- (MPKitExecStatus *)logScreen:(MPEvent *)event {
-    MPKitExecStatus *execStatus;
-
-    if (!forwardScreenViews) {
-        execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceBranchMetrics) returnCode:MPKitReturnCodeUnavailable];
-        return execStatus;
-    }
-
-    NSString *actionName = [NSString stringWithFormat:@"Viewed %@", event.name];
-
-    if (event.info.count > 0) {
-        [branchInstance userCompletedAction:actionName withState:event.info];
-    } else {
-        [branchInstance userCompletedAction:actionName];
-    }
-
-    execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceBranchMetrics) returnCode:MPKitReturnCodeSuccess];
-    return execStatus;
-}
-
 - (nonnull MPKitExecStatus *)openURL:(nonnull NSURL *)url options:(nullable NSDictionary<NSString *, id> *)options {
     [branchInstance handleDeepLink:url];
 


### PR DESCRIPTION
Part of the integration with Branch Metrics is being re-implemented to be server-to-server. Events will no longer be forwarded on the client side.