### PR TITLE
Pin Branch to 0.18.8

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "BranchMetrics/ios-branch-deep-linking" == 0.17.6
+github "BranchMetrics/ios-branch-deep-linking" == 0.18.8
 github "mparticle/mparticle-apple-sdk" ~> 6.15.0


### PR DESCRIPTION
Pinning it to the same version currently specified in the [.podspec](https://github.com/mparticle-integrations/mparticle-apple-integration-branchmetrics/blob/b665bfefb07ff740fedd99a95275779f9dfdd920/mParticle-BranchMetrics.podspec#L19)