### PR TITLE
Handle deep links at app startup.

### DIFF
--- a/mParticle-BranchMetrics/MPKitBranchMetrics.m
+++ b/mParticle-BranchMetrics/MPKitBranchMetrics.m
@@ -148,6 +148,10 @@ static BOOL _appleSearchAdsDebugMode;
             [self->_kitApi onAttributionCompleteWithResult:attributionResult error:nil];
         }];
 
+        // mParticle isn't calling back with the URL on startup fast enough or in the right order, so handle it here:
+        NSURL*URL = self.launchOptions[UIApplicationLaunchOptionsURLKey];
+        if (URL) [self.branchInstance handleDeepLinkWithNewSession:URL];
+
         dispatch_async(dispatch_get_main_queue(), ^{
             if (self.branchInstance) {
                 self.started = YES;


### PR DESCRIPTION
mParticle isn't calling back with the URL on startup fast enough or in the right order or something, so handle it in Branch startup.
