### PR TITLE
Make Commerce Event Custom Attribute Strings

### DIFF
--- a/mParticle-BranchMetrics/MPKitBranchMetrics.m
+++ b/mParticle-BranchMetrics/MPKitBranchMetrics.m
@@ -487,7 +487,7 @@ NSString *const ekBMAEnableAppleSearchAds = @"enableAppleSearchAds";
     }
     NSMutableDictionary<NSString*, NSString*>* mutableDictionary = [[NSMutableDictionary alloc] initWithDictionary:event.customData];
     if (mpEvent.customAttributes != nil) {
-        [mutableDictionary addEntriesFromDictionary:mpEvent.customAttributes];
+        [mutableDictionary addEntriesFromDictionary:[self stringDictionaryFromDictionary:dictionary]];
     }
     mutableDictionary[@"product_list_name"] = mpEvent.productListName;
     mutableDictionary[@"product_list_source"] = mpEvent.productListSource;


### PR DESCRIPTION
Ensures values from MPCommerceEvent.customAttributes are Strings before setting as BranchEvent.customData to conform to Branch's API requirements