### PR TITLE
Make CommerceEvent customAttribute Values Strings

### DIFF
--- a/mParticle-BranchMetrics/MPKitBranchMetrics.m
+++ b/mParticle-BranchMetrics/MPKitBranchMetrics.m
@@ -487,7 +487,8 @@ NSString *const ekBMAEnableAppleSearchAds = @"enableAppleSearchAds";
     }
     NSMutableDictionary<NSString*, NSString*>* mutableDictionary = [[NSMutableDictionary alloc] initWithDictionary:event.customData];
     if (mpEvent.customAttributes != nil) {
-        [mutableDictionary addEntriesFromDictionary:mpEvent.customAttributes];
+        [mutableDictionary addEntriesFromDictionary:[self stringDictionaryFromDictionary:mpEvent.customAttributes]];
+        event.customData = mutableDictionary;
     }
     mutableDictionary[@"product_list_name"] = mpEvent.productListName;
     mutableDictionary[@"product_list_source"] = mpEvent.productListSource;


### PR DESCRIPTION
Ensures values from MPCommerceEvent.customAttributes are Strings before setting as BranchEvent.customData to conform to Branch's API