### PR TITLE
Update to support iOS 15 NativeLink™ feature

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
                .upToNextMajor(from: "8.2.0")),
       .package(name: "Branch",
                url: "https://github.com/BranchMetrics/ios-branch-sdk-spm",
-               .upToNextMajor(from: "1.39.1")),
+               .upToNextMajor(from: "1.39.4")),
     ],
     targets: [
         .target(

--- a/mParticle-BranchMetrics.podspec
+++ b/mParticle-BranchMetrics.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-BranchMetrics/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.2'
-    s.ios.dependency 'Branch', '~> 1.39.1'
+    s.ios.dependency 'Branch', '~> 1.39.4'
 end

--- a/mParticle-BranchMetrics/MPKitBranchMetrics.m
+++ b/mParticle-BranchMetrics/MPKitBranchMetrics.m
@@ -160,6 +160,16 @@ NSString *const userIdentificationType = @"userIdentificationType";
         [self.branchInstance registerPluginName:@"mParticle - iOS" version:MPKitBranchMetricsVersionNumber];
         
         if (self.enableAppleSearchAds) [self.branchInstance delayInitToCheckForSearchAds];
+        
+        // iOS 15 Branch NativeLink™ support
+        // https://help.branch.io/developers-hub/docs/ios-advanced-features#nativelink-deferred-deep-linking
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wundeclared-selector"
+        if ([Branch respondsToSelector:@selector(checkPasteboardOnInstall)]) {
+            [Branch performSelector:@selector(checkPasteboardOnInstall)];
+        }
+        #pragma clang diagnostic pop
+        
         [self.branchInstance initSessionWithLaunchOptions:self.launchOptions
             isReferrable:YES
             andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {


### PR DESCRIPTION
Full information in the Branch iOS SDK documentation here: https://help.branch.io/developers-hub/docs/ios-advanced-features#nativelink-deferred-deep-linking

Note: Requires Branch iOS SDK version 1.39.4 or higher, but I've implemented the method call in our kit wrapper to fail gracefully if using an older version of their SDK. I also noticed something strange when cloning the Branch iOS repo...for some reason the master branch (which is ahead of the 1.39.4 release) doesn't include the new method, even though the release commit for 1.39.4 does. So just in case they accidentally (or purposefully) release a future update that removes the new method, our kit wrapper won't crash due to the graceful failure.