### PR TITLE
Call checkPasteboardOnInstall on Branch instance

### DIFF
--- a/mParticle-BranchMetrics/MPKitBranchMetrics.m
+++ b/mParticle-BranchMetrics/MPKitBranchMetrics.m
@@ -165,8 +165,8 @@ NSString *const userIdentificationType = @"userIdentificationType";
         // https://help.branch.io/developers-hub/docs/ios-advanced-features#nativelink-deferred-deep-linking
         #pragma clang diagnostic push
         #pragma clang diagnostic ignored "-Wundeclared-selector"
-        if ([Branch respondsToSelector:@selector(checkPasteboardOnInstall)]) {
-            [Branch performSelector:@selector(checkPasteboardOnInstall)];
+        if ([self.branchInstance respondsToSelector:@selector(checkPasteboardOnInstall)]) {
+            [self.branchInstance performSelector:@selector(checkPasteboardOnInstall)];
         }
         #pragma clang diagnostic pop
         


### PR DESCRIPTION
Hi there! I was just alerted to the 8.0.4 release of this kit with NativeLink support and was very excited to give it a go.

It looks like #41 added a call to the [instance method `checkPasteboardOnInstall`](https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/blob/08cccfac98ca64b53a666fcf15a7313d66abb141/Branch-SDK/Branch.m#L948) on the Branch class instead of a Branch instance, so NativeLink was never activating (though gracefully failing with the `respondsToSelector` check).