### PR TITLE
Update mParticle to Branch iOS SDK 1.45.0 and mParticle 8.9.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "BranchMetrics/ios-branch-deep-linking" ~> 1.43
-github "mparticle/mparticle-apple-sdk" ~> 8.8
+github "BranchMetrics/ios-branch-deep-linking" ~> 1.45
+github "mparticle/mparticle-apple-sdk" ~> 8.9

--- a/Examples/Carthage/Branch Example.xcodeproj/project.pbxproj
+++ b/Examples/Carthage/Branch Example.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -322,6 +323,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = "Branch Example/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mparticle.branchtesterapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -338,6 +340,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = "Branch Example/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mparticle.branchtesterapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Examples/Carthage/Cartfile
+++ b/Examples/Carthage/Cartfile
@@ -1,1 +1,1 @@
-github "mparticle-integrations/mparticle-apple-integration-branchmetrics"  ~> 7.0
+github "mparticle-integrations/mparticle-apple-integration-branchmetrics" ~> 8.1

--- a/Examples/Cocoapods/Branch Example.xcodeproj/project.pbxproj
+++ b/Examples/Cocoapods/Branch Example.xcodeproj/project.pbxproj
@@ -369,6 +369,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Branch Example/Branch Example.entitlements";
 				INFOPLIST_FILE = "Branch Example/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mparticle.branchtesterapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -382,6 +383,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Branch Example/Branch Example.entitlements";
 				INFOPLIST_FILE = "Branch Example/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mparticle.branchtesterapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Examples/Cocoapods/Podfile
+++ b/Examples/Cocoapods/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '9.0'
+platform :ios, '11.0'
 
 target 'Branch Example' do
     use_frameworks!

--- a/Examples/mParticle-Branch-Example/Podfile
+++ b/Examples/mParticle-Branch-Example/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '9.0'
+platform :ios, '11.0'
 use_frameworks!
 
 target 'mParticle' do

--- a/Examples/mParticle-Branch-Example/mParticle.xcodeproj/project.pbxproj
+++ b/Examples/mParticle-Branch-Example/mParticle.xcodeproj/project.pbxproj
@@ -430,6 +430,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = R63EM248DP;
 				INFOPLIST_FILE = mParticle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.branch.mParticleFortune;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -447,6 +448,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = R63EM248DP;
 				INFOPLIST_FILE = mParticle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.branch.mParticleFortune;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "mParticle-BranchMetrics",
-    platforms: [ .iOS(.v9) ],
+    platforms: [ .iOS(.v11) ],
     products: [
         .library(
             name: "mParticle-BranchMetrics",
@@ -13,10 +13,10 @@ let package = Package(
     dependencies: [
       .package(name: "mParticle-Apple-SDK",
                url: "https://github.com/mParticle/mparticle-apple-sdk",
-               .upToNextMajor(from: "8.2.0")),
+               .upToNextMajor(from: "8.9.0")),
       .package(name: "Branch",
                url: "https://github.com/BranchMetrics/ios-branch-sdk-spm",
-               .upToNextMajor(from: "1.39.4")),
+               .upToNextMajor(from: "1.45.0")),
     ],
     targets: [
         .target(

--- a/mParticle-BranchMetrics.podspec
+++ b/mParticle-BranchMetrics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-BranchMetrics"
-    s.version          = "8.0.6"
+    s.version          = "8.1.0"
     s.summary          = "BranchMetrics integration for mParticle"
 
     s.description      = <<-DESC
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
     s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-branchmetrics.git", :tag => s.version.to_s }
     s.social_media_url = "https://twitter.com/mparticle"
 
-    s.ios.deployment_target = "9.0"
+    s.ios.deployment_target = "11.0"
     s.ios.source_files      = 'mParticle-BranchMetrics/*.{h,m,mm}'
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.8'
-    s.ios.dependency 'Branch', '~> 1.43'
+    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.9'
+    s.ios.dependency 'Branch', '~> 1.45'
 end

--- a/mParticle-BranchMetrics/MPKitBranchMetrics.m
+++ b/mParticle-BranchMetrics/MPKitBranchMetrics.m
@@ -20,7 +20,7 @@ void MPKitBranchMetricsLoadClass(void) {
 - (MPMessageType) messageType;
 @end
 
-NSString *const MPKitBranchMetricsVersionNumber = @"8.0.6";
+NSString *const MPKitBranchMetricsVersionNumber = @"8.1.0";
 NSString *const ekBMAppKey = @"branchKey";
 NSString *const ekBMAForwardScreenViews = @"forwardScreenViews";
 NSString *const ekBMAEnableAppleSearchAds = @"enableAppleSearchAds";


### PR DESCRIPTION
## Summary
Update the Branch iOS SDK to 1.45.0, this has no public api changes just some internal changes for SKAN 4.0
Update mParticle SDK to 8.9.0

Increase the min iOS version to 11.0. Branch supports what the current version of Xcode supports, which is iOS 11+. I choose to update the version to 8.1.0, however that might not be in line with what mParticle does.

## Testing Plan
Test apps integrate successfully and regression tests pass.

