### PR TITLE
feat: Add NoLocation target to SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,10 @@ let package = Package(
         .library(
             name: "mParticle-BranchMetrics",
             targets: ["mParticle-BranchMetrics"]),
+        .library(
+            name: "mParticle-BranchMetrics-NoLocation",
+            targets: ["mParticle-BranchMetrics-NoLocation"]
+        )
     ],
     dependencies: [
       .package(name: "mParticle-Apple-SDK",
@@ -21,8 +25,21 @@ let package = Package(
     targets: [
         .target(
             name: "mParticle-BranchMetrics",
-            dependencies: ["mParticle-Apple-SDK","Branch"],
+            dependencies: [
+                .product(name: "mParticle-Apple-SDK", package: "mParticle-Apple-SDK"),
+                .product(name: "Branch", package: "Branch"),
+            ],
             path: "mParticle-BranchMetrics",
-            publicHeadersPath: "."),
+            publicHeadersPath: "."
+        ),
+        .target(
+            name: "mParticle-BranchMetrics-NoLocation",
+            dependencies: [
+                .product(name: "mParticle-Apple-SDK-NoLocation", package: "mParticle-Apple-SDK"),
+                .product(name: "Branch", package: "Branch"),
+            ],
+            path: "SPM/mParticle-BranchMetrics-NoLocation",
+            publicHeadersPath: "."
+        )
     ]
 )

--- a/SPM/mParticle-BranchMetrics-NoLocation
+++ b/SPM/mParticle-BranchMetrics-NoLocation
@@ -1,0 +1,1 @@
+../mParticle-BranchMetrics

--- a/mParticle-BranchMetrics/MPKitBranchMetrics.h
+++ b/mParticle-BranchMetrics/MPKitBranchMetrics.h
@@ -1,8 +1,10 @@
 #import <Foundation/Foundation.h>
 #if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
-#import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle.h>
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+    #import <mParticle_Apple_SDK_NoLocation/mParticle.h>
 #else
-#import "mParticle.h"
+    #import "mParticle.h"
 #endif
 
 extern void MPKitBranchMetricsLoadClass(void)

--- a/mParticle-BranchMetrics/mParticle_BranchMetrics.h
+++ b/mParticle-BranchMetrics/mParticle_BranchMetrics.h
@@ -7,8 +7,10 @@ FOUNDATION_EXPORT double mParticle_BranchMetricsVersionNumber;
 FOUNDATION_EXPORT const unsigned char mParticle_BranchMetricsVersionString[];
 
 #if defined(__has_include) && __has_include(<mParticle_BranchMetrics/MPKitBranchMetrics.h>)
-#import <mParticle_BranchMetrics/MPKitBranchMetrics.h>
+    #import <mParticle_BranchMetrics/MPKitBranchMetrics.h>
+#elif defined(__has_include) && __has_include(<mParticle_BranchMetrics_NoLocation/MPKitBranchMetrics.h>)
+    #import <mParticle_BranchMetrics_NoLocation/MPKitBranchMetrics.h>
 #else
-#import "MPKitBranchMetrics.h"
+    #import "MPKitBranchMetrics.h"
 #endif
 


### PR DESCRIPTION
 ## Summary
Add dedicated NoLocation target to SPM with a dependency on the NoLocation version of the mParticle SDK. This prevents the issue where a customer adds the NoLocation SDK and then the kit depends on the standard version, which causes both to be included.

 ## Testing Plan
- Confirmed in a test app that both targets work as expected

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5439
