### PR TITLE
fix:BranchEvent.h not found on SPM package

### DIFF
--- a/mParticle-BranchMetrics/MPKitBranchMetrics.m
+++ b/mParticle-BranchMetrics/MPKitBranchMetrics.m
@@ -9,7 +9,11 @@
 #import <UserNotifications/UNUserNotificationCenter.h>
 #endif
 #import "mParticle_BranchMetrics.h"
-#import <BranchSDK/BranchEvent.h>
+#if defined(__has_include) && __has_include(<BranchSDK/BranchEvent.h>)
+    #import <BranchSDK/BranchEvent.h>
+#else
+    #import "BranchEvent.h"
+#endif
 
 __attribute__((constructor))
 void MPKitBranchMetricsLoadClass(void) {


### PR DESCRIPTION
## Reference
https://mparticle-eng.atlassian.net/browse/PRODRDMP-6014

## Summary
A customer noted that adding the Branch kit as an SPM package resulted in BranchEvent.h not found and I was able to reproduce

## Motivation
Bug fix

## Testing Instructions
E2E testing locally, added the package locally to the higgs project and the "BranchEvent.h not found" error disappeared after implementing the code change