### PR TITLE
Fix include check

### DIFF
--- a/mParticle-BranchMetrics/MPKitBranchMetrics.m
+++ b/mParticle-BranchMetrics/MPKitBranchMetrics.m
@@ -1,5 +1,5 @@
 #import "MPKitBranchMetrics.h"
-#if defined(__has_include) && __has_include(<Branch/Branch.h>)
+#if defined(__has_include) && __has_include(<BranchSDK/Branch.h>)
     #import <BranchSDK/Branch.h>
 #else
     #import "Branch.h"


### PR DESCRIPTION
## Reference
SDK-0 -- Fix include check.

## Summary
After updating `mParticle-BranchMetrics` to version `8.2.2` our iOS builds started failing. After having a closer look it turned out that it's caused by the Branch 2.2.0 update where the [include check wasn't updated](https://github.com/mparticle-integrations/mparticle-apple-integration-branchmetrics/pull/49/files#diff-ce0fd117f0416671e7004b5ac3d94b4333d16e4b16574d86db12deab4c3b00d6R2).

![Snímek obrazovky 2024-01-22 v 12 25 50](https://github.com/mparticle-integrations/mparticle-apple-integration-branchmetrics/assets/118170684/48e695cc-36f1-4da2-b379-206f09af4079)

## Motivation
Failing builds

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
