### PR TITLE
feat: Update Branch to 3.4.1 up to next major

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
                .upToNextMajor(from: "8.9.0")),
       .package(name: "BranchSDK",
                url: "https://github.com/BranchMetrics/ios-branch-sdk-spm",
-               .upToNextMajor(from: "3.0.1")),
+               .upToNextMajor(from: "3.4.1")),
     ],
     targets: [
         .target(

--- a/mParticle-BranchMetrics.podspec
+++ b/mParticle-BranchMetrics.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "12.0"
     s.ios.source_files      = 'mParticle-BranchMetrics/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.9'
-    s.ios.dependency 'BranchSDK', '~> 3.0.1'
+    s.ios.dependency 'BranchSDK', '~> 3.4'
 end


### PR DESCRIPTION
We were previous fuzzy pinning to 3.0.1, which for SPM works as expected (up to next major), but for CocoaPods, was limited updates to 3.0.x only. There is a new privacy manifest fix for Cocoapods in 3.4.1, so I've adjusted our fuzzy pinning to 3.4 for cocopods so it will pull in any 3.x.x release >= 3.4 (which will currently be 3.4.1) and bumped SPM to match (but used 3.4.1 because SPM has sane matching options). Unfortunately there is no way to set 3.4.1 as the min version for Cocoapods while also pinning to next major, which is why I used 3.4.

Tested in both a Cocoapods and SPM test app to see that it pulls in the correct dependencies and builds properly. No E2E required for this as SPM was already pulling in that version automatically.