### PR TITLE
fix: Address Edge Case Upgrade Crash

### DIFF
--- a/mParticle-BranchMetrics/MPKitBranchMetrics.m
+++ b/mParticle-BranchMetrics/MPKitBranchMetrics.m
@@ -193,7 +193,7 @@ NSString *const userIdentificationType = @"userIdentificationType";
             
             NSMutableDictionary *userInfo = [@{
                 mParticleKitInstanceKey: [[self class] kitCode],
-                @"branchKey": branchKey
+                @"branchKey": (self.configuration[ekBMAppKey] != nil) ? self.configuration[ekBMAppKey] : @""
             } mutableCopy];
 
             [[NSNotificationCenter defaultCenter]


### PR DESCRIPTION
## Summary
 - When upgrading from 8.0.6 to 8.5.1 (which was Branch: 1.45.2 to Branch: 3.10.0) the branchKey would de-initialize before it was used in the async block.

 ## Testing Plan
 - [x] Was this tested locally? Yes
 - Tested using simulator and confirmed data flowing to the Branchmetrics Kit

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7340
